### PR TITLE
feat: Multi-container site-packages support with isolated package directories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,6 +334,55 @@ pip install mlt-toolbox
 pip install mlt-toolbox==0.1.0
 ```
 
+#### Multi-Container Support
+
+When working with multiple containers on the same remote host (different projects or branches), mltoolbox uses project-specific site-packages caching to avoid conflicts:
+
+**How It Works:**
+
+1. **Isolated Package Directories**: Each container mounts its site-packages to a unique host directory:
+   ```yaml
+   volumes:
+     - ~/.cache/python-packages/${CONTAINER_NAME}:/usr/local/lib/python3.11/dist-packages
+   ```
+
+2. **No Conflicts**: Different containers can have:
+   - Different Python versions
+   - Different package versions
+   - Completely isolated dependencies
+
+3. **Path Translation**: `mlt` translates both:
+   - **Project paths**: `/home/ubuntu/projects/X` ↔ `/workspace/X`
+   - **Library paths**: `~/.cache/python-packages/container-name` ↔ `/usr/local/lib/pythonX.Y/dist-packages`
+
+**Example Setup:**
+
+```bash
+# Container 1: causalab-main with Python 3.11
+~/.cache/python-packages/causalab-main/  → /usr/local/lib/python3.11/dist-packages
+
+# Container 2: causalab-feature with Python 3.12
+~/.cache/python-packages/causalab-feature/ → /usr/local/lib/python3.12/dist-packages
+
+# No conflicts! Each has isolated packages
+```
+
+**Container Detection:**
+
+When multiple containers exist, `mlt` automatically detects the correct one based on:
+1. Current project directory name
+2. CONTAINER_NAME in `.env` file
+3. Docker ps filtering by project name
+
+Each Zed instance runs in its project directory, so `mlt` always connects to the right container.
+
+**Benefits:**
+
+- Work on multiple branches simultaneously without package conflicts
+- Different Python versions per project
+- Clean separation of dependencies
+- Zed LSP works correctly for all containers independently
+
 ### Branch Strategy
 
 - **Main branch**: Stable releases

--- a/src/mltoolbox/templates/docker-compose.yml.j2
+++ b/src/mltoolbox/templates/docker-compose.yml.j2
@@ -22,8 +22,8 @@ services:
       - ~/.claude:/root/.claude
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp/ray_lockfiles:/root/ray_lockfiles
-      # Mount Python site-packages for LSP to read library code (read-write to allow package installs)
-      - /usr/local/lib/python{{ python_version_short }}/dist-packages:/usr/local/lib/python{{ python_version_short }}/dist-packages
+      # Mount Python site-packages to project-specific cache (isolates packages per container)
+      - ~/.cache/python-packages/${CONTAINER_NAME}:/usr/local/lib/python{{ python_version_short }}/dist-packages
       - type: bind
         source: ~/.ssh
         target: /root/.ssh


### PR DESCRIPTION
## Summary

Adds support for multiple containers on the same remote host without package conflicts by using project-specific site-packages caching and dual path translation.

## Changes

### 1. Project-Specific Site-Packages Mount
- **Updated**: `docker-compose.yml.j2` template
- **Before**: All containers shared `/usr/local/lib/pythonX.Y/dist-packages`
- **After**: Each container uses `~/.cache/python-packages/${CONTAINER_NAME}`
- **Benefit**: Complete isolation - different Python versions and packages per container

### 2. Dual Path Translation in LSP Proxy
- **Updated**: `mlt/config.py` - Added `get_all_path_mappings()`
- **Updated**: `mlt/lsp_proxy.py` - Translates both project and library paths
- **Translates**:
  - Project paths: `/home/ubuntu/projects/X` ↔ `/workspace/X`
  - Library paths: `~/.cache/python-packages/X` ↔ `/usr/local/lib/pythonX.Y/dist-packages`

### 3. Documentation
- **Updated**: `CLAUDE.md` - Added "Multi-Container Support" section
- Documents how isolation works, examples, and benefits

## Benefits

✅ Work on multiple branches simultaneously without conflicts  
✅ Different Python versions per project  
✅ Isolated dependencies per container  
✅ Zed LSP works correctly for all containers  
✅ Navigate to stdlib/library files in editor  

## Testing

- [ ] Verify multiple containers can run on same host
- [ ] Verify LSP works for each container independently
- [ ] Verify stdlib navigation works with project-specific packages
- [ ] Test with different Python versions

## Breaking Changes

None - existing single-container setups continue to work. The site-packages mount path changes but this is transparent to users.